### PR TITLE
Add 'Haze' to weather condition types

### DIFF
--- a/src/Entities/WeatherConditionType.cs
+++ b/src/Entities/WeatherConditionType.cs
@@ -38,6 +38,11 @@
         /// <summary>
         ///     Clouds weather condition
         /// </summary>
-        Clouds
+        Clouds,
+        
+        /// <summary>
+        ///     Haze weather condition
+        /// </summary>
+        Haze
     }
 }


### PR DESCRIPTION
Need to add this to fix the following error I am getting...

Error converting value "Haze" to type 'OpenWeatherMap.Entities.WeatherConditionType'. Path 'weather[0].main', line 1, position 70.